### PR TITLE
Fix unsubscribe bug and add test

### DIFF
--- a/src/observer.ts
+++ b/src/observer.ts
@@ -32,7 +32,7 @@ export class Observable<DataType> {
    */
   private unsubscribe(index: number): void {
     // TODO: still need to add tests for this
-    this.observers = this.observers.filter((_, ObsIndex: number) => ObsIndex === index);
+    this.observers = this.observers.filter((_, ObsIndex: number) => ObsIndex !== index);
   }
 
   /**

--- a/tests/observer.test.ts
+++ b/tests/observer.test.ts
@@ -47,4 +47,13 @@ describe('Observer tests', () => {
         sub.unsubscribe();
         obs.unsubscribeAll('test-cache');
     })
+
+    test('unsubscribe should stop receiving updates', done => {
+        const sub = observer.subscribe('test-unsubscribe', value => {
+            done(new Error('Should not receive updates after unsubscribe'));
+        });
+        sub.unsubscribe();
+        observer.push('test-unsubscribe', true);
+        setTimeout(() => done(), 20);
+    })
 })


### PR DESCRIPTION
## Summary
- fix observer unsubscribe logic
- add unit test to ensure unsubscribe stops events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846f2f38a00832c822e01d2d7914def