### PR TITLE
Add GitHub Action for CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: CI
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm t -- --verbose


### PR DESCRIPTION
## Summary
- add a workflow named `CI` to run Jest tests on pushes or PRs

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6846f50b20b4832ca86373f9f9c4a142