### PR TITLE
Add crypto import in docs and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ The package supports event-driven execution, making it easy to integrate with ex
 
 ```typescript
 // Example of how to use the library
+import * as crypto from "crypto";
 import { Rootsby } from "rootsby/workflow";
 import { 
     WorkflowConfig, 

--- a/examples/basic-example.ts
+++ b/examples/basic-example.ts
@@ -1,3 +1,4 @@
+import * as crypto from "crypto";
 import { ExprOp, WorkflowConfig, WorkflowEvent, WorkflowFunctionInput, WorkflowType } from "../src/types";
 import { Rootsby } from "../src/workflow";
 


### PR DESCRIPTION
## Summary
- include `crypto` import in README usage example
- update example script to import `crypto`

## Testing
- `npx ts-node@10.9.2 --transpile-only examples/index.ts` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f9257cf4832c93cee25ad447a740